### PR TITLE
Fix issues with aliases as usernames

### DIFF
--- a/baserepo.py
+++ b/baserepo.py
@@ -260,7 +260,7 @@ class StudentRepo(Repo):
             'semester': semester,
             'section': section,
             'assignment': assignment,
-            'user': user
+            'user': user.translate(str.maketrans('.','-')) # Replace .s with -s
         }
 
         return "{semester}-{section}-{assignment}-{user}".format(**fmt)

--- a/config.py
+++ b/config.py
@@ -69,7 +69,7 @@ class _Config(UserDict):
                         # Their GitLab username (single sign on)
                         "username": {
                             "type": "string",
-                            "pattern": "^\w+$",
+                            "pattern": "^[\w\.\-]+$",
                         },
 
                         # Their GitLab id (might be handy, but we'd have


### PR DESCRIPTION
I fixed the schema to properly validate aliases and the repo url name generator to correctly convert `.`s to `-`s, which is what Gitlab does with `.`s in repo names.

Fixes #18 .